### PR TITLE
Add FMM unit dependency

### DIFF
--- a/server/fhirconsole.lpi
+++ b/server/fhirconsole.lpi
@@ -401,7 +401,7 @@
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir);..\library"/>
       <Libraries Value="..\dependencies\openssl\$(TargetOS)-$(TargetCPU)"/>
-      <OtherUnitFiles Value="admin;tx"/>
+      <OtherUnitFiles Value="admin;tx;..\dependencies\FMM"/>
       <UnitOutputDirectory Value="lib\$(BuildMode)"/>
     </SearchPaths>
     <Parsing>


### PR DESCRIPTION
Needed for FMM to be compiled with FPC/Lazarus on Windows.